### PR TITLE
Fixed behavior of doSelect on EINTR

### DIFF
--- a/select_linux.go
+++ b/select_linux.go
@@ -5,7 +5,15 @@ import (
 )
 
 func doSelect(nfd int, r *syscall.FdSet, w *syscall.FdSet, e *syscall.FdSet, timeout *syscall.Timeval) (changed bool, err error) {
-	n, err := syscall.Select(nfd, r, w, e, timeout)
+	var n int
+
+	for {
+		n, err = syscall.Select(nfd, r, w, e, timeout)
+		if err == nil || err != syscall.EINTR {
+			break
+		}
+	}
+
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
I've been using this library for quite some time now and recently after upgrading all of my projects to go 1.14 I noticed that its gpio watcher would panic from time to time in [`fdSelect` in watcher.go line 122](https://github.com/tm320/gpio/blob/master/watcher.go#L122).

After some investigation I found that the `syscall.Select` in `doSelect` terminates with `EINTR`.
I have no clue as to why that did not happen before, but possibly the upgrade to go 1.14 or other changes in my environment associated with it caused it.

Anyway, if I remember correctly it should be safe to retry a select after it terminated with `EINTR`,
so I modified `doSelect` accordingly.


